### PR TITLE
Added an INSTANCE_NAME variable 

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-work: python configure_zopeconf.py; bin/instance run test.py
+work: python configure_zopeconf.py; bin/plone run test.py

--- a/bin/compile
+++ b/bin/compile
@@ -63,6 +63,15 @@ else
     echo "Use default buildout verbosity" | indent
 fi
 
+echo "-----> Read INSTANCE_NAME from env vars, or use default"
+if [ -f $ENV_DIR/INSTANCE_NAME ]; then
+    export "INSTANCE=$(cat $ENV_DIR/INSTANCE_NAME)"
+    echo "Use instance name: ${INSTANCE}" | indent
+else
+    export "INSTANCE=instance"
+    echo "Use default instance name" | indent
+fi
+
 echo "-----> Read BOOTSTRAP_PY_URL from env vars, or use default"
 if [ -f $ENV_DIR/BOOTSTRAP_PY_URL ]; then
     export "BOOTSTRAP_PY_URL=$(cat $ENV_DIR/BOOTSTRAP_PY_URL)"
@@ -80,8 +89,8 @@ echo "-----> Run bin/buildout -c ${BUILDOUT_CFG} ${BUILDOUT_VERBOSITY}"
 bin/buildout -c $BUILDOUT_CFG $BUILDOUT_VERBOSITY
 
 echo "-----> Fix paths in zope.conf"
-sed "s|${BUILD_DIR}|/app|" parts/instance/etc/zope.conf > zope.conf.new
-mv zope.conf.new parts/instance/etc/zope.conf
+sed "s|${BUILD_DIR}|/app|" parts/$INSTANCE/etc/zope.conf > zope.conf.new
+mv zope.conf.new parts/$INSTANCE/etc/zope.conf
 
 echo "-----> Copy results to cache"
 cp -r $BUILD_DIR/bin $CACHE_DIR

--- a/bin/compile
+++ b/bin/compile
@@ -105,7 +105,7 @@ cp -r $BUILD_DIR/parts $INSTALL_DIR
 cp -r $BUILD_DIR/var $INSTALL_DIR
 
 echo "-----> Copy configure_zopeconf.py script to slug"
-curl -OL "https://raw.githubusercontent.com/plone/heroku-buildpack-plone/master/configure_zopeconf.py"
+curl -OL "https://raw.githubusercontent.com/pndk/heroku-buildpack-plone/master/configure_zopeconf.py"
 cp -r $BUILD_DIR/configure_zopeconf.py $INSTALL_DIR
 
 echo "Done" | indent

--- a/bin/compile
+++ b/bin/compile
@@ -68,7 +68,7 @@ if [ -f $ENV_DIR/INSTANCE_NAME ]; then
     export "INSTANCE=$(cat $ENV_DIR/INSTANCE_NAME)"
     echo "Use instance name: ${INSTANCE}" | indent
 else
-    export "INSTANCE=instance"
+    export "INSTANCE=plone"
     echo "Use default instance name" | indent
 fi
 

--- a/bin/release
+++ b/bin/release
@@ -1,16 +1,10 @@
 #!/usr/bin/env bash
 # bin/release <build-dir>
 
-echo "-----> Read INSTANCE_NAME from env vars, or use default"
-if [ -f $ENV_DIR/INSTANCE_NAME ]; then
-    export "INSTANCE=$(cat $ENV_DIR/INSTANCE_NAME)"
-    echo "Use instance name: ${INSTANCE}" | indent
-else
-
 cat << EOF
 ---
 addons:
   - heroku-postgresql:dev
 default_process_types:
-  web: python configure_zopeconf.py; bin/$INSTANCE console
+  web: python configure_zopeconf.py; bin/plone console
 EOF

--- a/bin/release
+++ b/bin/release
@@ -1,10 +1,16 @@
 #!/usr/bin/env bash
 # bin/release <build-dir>
 
+echo "-----> Read INSTANCE_NAME from env vars, or use default"
+if [ -f $ENV_DIR/INSTANCE_NAME ]; then
+    export "INSTANCE=$(cat $ENV_DIR/INSTANCE_NAME)"
+    echo "Use instance name: ${INSTANCE}" | indent
+else
+
 cat << EOF
 ---
 addons:
   - heroku-postgresql:dev
 default_process_types:
-  web: python configure_zopeconf.py; bin/instance console
+  web: python configure_zopeconf.py; bin/$INSTANCE console
 EOF

--- a/configure_zopeconf.py
+++ b/configure_zopeconf.py
@@ -4,8 +4,8 @@ go through the zope.conf and searc/replace values. Bad Plone!"""
 import os
 
 DIR = '/app/'
-zope_conf_orig = DIR + 'parts/instance/etc/zope.conf'
-zope_conf_new = DIR + 'parts/instance/etc/zope.conf.new'
+zope_conf_orig = DIR + 'parts/plone/etc/zope.conf'
+zope_conf_new = DIR + 'parts/plone/etc/zope.conf.new'
 
 with open(zope_conf_new, 'wt') as fout:
     with open(zope_conf_orig, 'rt') as fin:


### PR DESCRIPTION
There are scenarios where your instance is not called 'instance'
It is now possible to override the default name with your own custom name
using

   heroku config:set INSTANCE_NAME=customname

now compile will look for things under 'parts/customname/....
